### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a sample project that lets you try out either option in a few easy steps
 ### GitHub Codespaces
 Follow these steps to open this sample in a Codespace:
 1. Click the Code drop-down menu and select the **Open with Codespaces** option.
-1. Select **+ New codespace** at the bottom on the pane. If you don't own the repo, this will create a fork of this repository under your account.
+1. Select **+ New codespace** at the bottom on the pane.
 
 For more info, check out the [GitHub documentation](https://docs.github.com/en/free-pro-team@latest/github/developing-online-with-codespaces/creating-a-codespace#creating-a-codespace).
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,30 @@
 # Try Out Development Containers: Rust
 
-This is a sample project that lets you try out the **[VS Code Remote - Containers](https://aka.ms/vscode-remote/containers)** extension in a few easy steps.
+A **development container** is a running [Docker](https://www.docker.com) container with a well-defined tool/runtime stack and its prerequisites. You can try out development containers with **[GitHub Codespaces](https://github.com/features/codespaces)** or **[Visual Studio Code Remote - Containers](https://aka.ms/vscode-remote/containers)**.
 
-> **Note:** If you're following the quick start, you can jump to the [Things to try](#things-to-try) section. 
+This is a sample project that lets you try out either option in a few easy steps. We have a variety of other [vscode-remote-try-*](https://github.com/search?q=org%3Amicrosoft+vscode-remote-try-&type=Repositories) sample projects, too.
+
+> **Note:** If you already have a Codespace or dev container, you can jump to the [Things to try](#things-to-try) section.
 
 ## Setting up the development container
 
-Follow these steps to open this sample in a container:
+### GitHub Codespaces
+Follow these steps to open this sample in a Codespace:
+1. Click the Code drop-down menu and select the **Open with Codespaces** option.
+1. Select **+ New codespace** at the bottom on the pane. If you don't own the repo, this will create a fork of this repository under your account.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started).
+For more info, check out the [GitHub documentation](https://docs.github.com/en/free-pro-team@latest/github/developing-online-with-codespaces/creating-a-codespace#creating-a-codespace).
+
+### VS Code Remote - Containers
+Follow these steps to open this sample in a container using the VS Code Remote - Containers extension:
+
+1. If this is your first time using a development container, please ensure your system meets the pre-reqs (i.e. have Docker installed) in the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started).
 
 2. To use this repository, you can either open the repository in an isolated Docker volume:
 
     - Press <kbd>F1</kbd> and select the **Remote-Containers: Try a Sample...** command.
-    - Choose the "Rust" sample, wait for the container to start and try things out!
-        > **Note:** Under the hood, this will use **Remote-Containers: Open Repository in Container...** command to clone the source code in a Docker volume instead of the local filesystem.
+    - Choose the "Rust" sample, wait for the container to start, and try things out!
+        > **Note:** Under the hood, this will use the **Remote-Containers: Clone Repository in Container Volume...** command to clone the source code in a Docker volume instead of the local filesystem. [Volumes](https://docs.docker.com/storage/volumes/) are the preferred mechanism for persisting container data.
 
    Or open a locally cloned copy of the code:
 
@@ -24,7 +34,7 @@ Follow these steps to open this sample in a container:
 
 ## Things to try
 
-Once you have this sample opened in a container, you'll be able to work with it like you would locally.
+Once you have this sample opened, you'll be able to work with it like you would locally.
 
 > **Note:** This container runs as a non-root user with sudo access by default. Comment out `"remoteUser": "vscode"` in `.devcontainer/devcontainer.json` if you'd prefer to run as root.
 
@@ -33,6 +43,7 @@ Some things to try:
 1. **Edit:**
    - Open `main.rs`
    - Try adding some code and check out the language features.
+   - Notice that several extensions are already installed in the container, such as Rust support for VS Code, since the `.devcontainer/devcontainer.json` lists a set of extensions, including `"rust-lang.rust"`, to install automatically when the container is created.
 1. **Terminal:** Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>\`</kbd> and type `uname` and other Linux commands from the terminal window.
 1. **Build, Run, and Debug:**
    - Open `main.rs`


### PR DESCRIPTION
Updated readme to include Remote-Containers and Codespaces, following the practices from microsoft/vscode-remote-try-node#15.

We previously chatted about converting the remote-try-* repos to template repositories. I figured the PRs I'm opening with updates could also be a good spot to chat about/remind us of this change as well.