### PR TITLE
use rust lang's analyzer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
 			"extensions": [
 				"vadimcn.vscode-lldb",
 				"mutantdino.resourcemonitor",
-				"matklad.rust-analyzer",
+				"rust-lang.rust-analyzer",
 				"tamasfe.even-better-toml",
 				"serayuzgur.crates"
 			]


### PR DESCRIPTION
Update the extension name to `"rust-lang.rust-analyzer"` which seems to be the Rust Lang's supported rust-analyzer extension. I believe rust.analyzer was accepted by Rust Lang as the new LSP implementation for Rust. 